### PR TITLE
Fix incorrect reads from some DS1302 versions.

### DIFF
--- a/DS1302.h
+++ b/DS1302.h
@@ -172,7 +172,9 @@ private:
   //
   // Args:
   //   value: byte to shift out
-  void writeOut(uint8_t value);
+  //   readAfter: whether this will be followed by a read; if so, it
+  //     will leave io_pin_ as INPUT.
+  void writeOut(uint8_t value, bool readAfter = false);
 
   // Reads in a byte from the IO pin.
   //


### PR DESCRIPTION
The code as provided worked for me on a DS1302 labelled "DS1302 0137A4
618AE", but not on one labelled "DS1302 1528C2 +163AN"; the latter
produces good data and bad data on alternate seconds. Comparing the code
with Krodal's public domain DS1302 library (which works on both)
revealed that this library has no explicit delays, and after an 8-bit
write could lower the clock line while the IO pin was still in output
mode.

Add delays after IO operations that need them, and fix the 8-bit write
problem.

I suspect this'll fix issues #3 and #7 (the latter looks like exactly what I was seeing)...