### PR TITLE
Add Time constructor from unix timestamp

### DIFF
--- a/DS1302.cpp
+++ b/DS1302.cpp
@@ -121,6 +121,66 @@ Time::Time(uint32_t t) {
   date = days + 1;
 }
 
+
+/**************************************************************************/
+/*!
+    @brief  Given a date, return number of days since 2000/01/01,
+            valid for 2000--2099
+    @param y Year
+    @param m Month
+    @param d Day
+    @return Number of days
+*/
+/**************************************************************************/
+static uint16_t date_to_days(uint16_t y, uint8_t m, uint8_t d) {
+  if (y >= 2000U)
+    y -= 2000U;
+  uint16_t days = d;
+  for (uint8_t i = 1; i < m; ++i)
+    days += daysInMonth[i - 1];
+  if (m > 2 && y % 4 == 0)
+    ++days;
+  return days + 365 * y + (y + 3) / 4 - 1;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Given a number of days, hours, minutes, and seconds, return the
+   total seconds
+    @param days Days
+    @param h Hours
+    @param m Minutes
+    @param s Seconds
+    @return Number of seconds total
+*/
+/**************************************************************************/
+static uint32_t time_to_ulong(uint16_t days, uint8_t h, uint8_t m, uint8_t s) {
+  return ((days * 24ul + h) * 60 + m) * 60 + s;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Return Unix time: seconds since 1 Jan 1970.
+
+    @see The `DateTime::DateTime(uint32_t)` constructor is the converse of
+        this method.
+
+    @return Number of seconds since 1970-01-01 00:00:00.
+*/
+/**************************************************************************/
+uint32_t Time::unixtime(void) const {
+  uint32_t t;
+  uint16_t days = date_to_days(yr, mon, date);
+  t = time_to_ulong(days, hr, min, sec);
+  t += SECONDS_FROM_1970_TO_2000; // seconds from 1970 to 2000
+
+  return t;
+}
+
+int32_t Time::operator-(const Time &other) {
+  return this->unixtime() - other.unixtime();
+}
+
 DS1302::DS1302(const uint8_t ce_pin, const uint8_t io_pin,
                const uint8_t sclk_pin) {
   ce_pin_ = ce_pin;

--- a/DS1302.cpp
+++ b/DS1302.cpp
@@ -104,7 +104,7 @@ Time::Time(uint32_t t) {
   hr = t % 24;
   uint16_t days = t / 24;
   uint8_t leap;
-  for (yr = 0;; ++yr) {
+  for (yr = 2000;; ++yr) {
     leap = yr % 4 == 0;
     if (days < 365U + leap)
       break;

--- a/DS1302.h
+++ b/DS1302.h
@@ -47,6 +47,8 @@ class Time {
   uint8_t mon;
   Day day;
   uint16_t yr;
+  uint32_t unixtime(void) const;
+  int32_t operator-(const Time &other);
 };
 
 // An interface to the Dallas Semiconductor DS1302 Real Time Clock (RTC) chip.

--- a/DS1302.h
+++ b/DS1302.h
@@ -9,6 +9,9 @@
 
 #include <stdint.h>
 
+// Unixtime for 2000-01-01 00:00:00, useful for initialization
+const uint32_t SECONDS_FROM_1970_TO_2000 = 946684800;
+
 // Class representing a particular time and date.
 class Time {
  public:
@@ -35,6 +38,7 @@ class Time {
   Time(uint16_t yr, uint8_t mon, uint8_t date,
        uint8_t hr, uint8_t min, uint8_t sec,
        Day day);
+  Time(uint32_t t = SECONDS_FROM_1970_TO_2000);
 
   uint8_t sec;
   uint8_t min;


### PR DESCRIPTION
This PR adds a constructor that builds `Time` from a unix timestamp. This is build on [a similar constructor in Adafruit RTClib](https://github.com/adafruit/RTClib/blob/master/src/RTClib.cpp). That code is MIT, so it should be fine to copy. BTW, you should consider adding a license for this library. 

The reason for this change is that I would like to keep my RTC in sync using the network time protocol, and the code I found to do this gives the current time in the unix timestamp.